### PR TITLE
Initialize Spring Boot auction API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# biddingplatform
+# Bidding Platform
+
+## Development
+
+1. Start PostgreSQL using Docker Compose:
+   ```bash
+   docker-compose up -d
+   ```
+2. Run the Spring Boot application:
+   ```bash
+   mvn spring-boot:run
+   ```
+
+The database will be preloaded with tables, indexes, and sequences from `db/init.sql`.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,31 @@
    ```
 
 The database will be preloaded with tables, indexes, and sequences from `db/init.sql`.
+
+### Authentication
+
+Register a user and obtain a JWT token:
+
+```
+POST /api/v1/auth/register
+{
+  "username": "user",
+  "password": "pass"
+}
+```
+
+Login to receive a JWT token:
+
+```
+POST /api/v1/auth/login
+{
+  "username": "user",
+  "password": "pass"
+}
+```
+
+Include the token in the `Authorization` header for all other requests:
+
+```
+Authorization: Bearer <token>
+```

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,48 @@
+-- Sequences
+CREATE SEQUENCE IF NOT EXISTS auction_id_seq START 1;
+CREATE SEQUENCE IF NOT EXISTS bid_id_seq START 1;
+CREATE SEQUENCE IF NOT EXISTS watchlist_item_id_seq START 1;
+
+-- Tables
+CREATE TABLE IF NOT EXISTS auctions (
+    id BIGINT PRIMARY KEY DEFAULT nextval('auction_id_seq'),
+    title VARCHAR(255),
+    description VARCHAR(1000),
+    current_bid NUMERIC(19,2),
+    minimum_bid NUMERIC(19,2),
+    image_url VARCHAR(255),
+    category VARCHAR(255),
+    organic BOOLEAN,
+    weight VARCHAR(255),
+    location VARCHAR(255),
+    end_time TIMESTAMP,
+    created_at TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS bids (
+    id BIGINT PRIMARY KEY DEFAULT nextval('bid_id_seq'),
+    auction_id BIGINT REFERENCES auctions(id) ON DELETE CASCADE,
+    amount NUMERIC(19,2),
+    bidder_name VARCHAR(255),
+    timestamp TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS categories (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255),
+    icon VARCHAR(255),
+    active_auctions INT
+);
+
+CREATE TABLE IF NOT EXISTS watchlist_items (
+    id BIGINT PRIMARY KEY DEFAULT nextval('watchlist_item_id_seq'),
+    user_id BIGINT,
+    auction_id BIGINT REFERENCES auctions(id) ON DELETE CASCADE,
+    added_at TIMESTAMP
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_auctions_category ON auctions(category);
+CREATE INDEX IF NOT EXISTS idx_bids_auction_id ON bids(auction_id);
+CREATE INDEX IF NOT EXISTS idx_watchlist_user ON watchlist_items(user_id);
+CREATE INDEX IF NOT EXISTS idx_watchlist_auction ON watchlist_items(auction_id);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: bidding
+      POSTGRES_USER: bidding
+      POSTGRES_PASSWORD: bidding
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
@@ -44,6 +48,23 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>bidding-platform</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>bidding-platform</name>
+    <description>Auction bidding platform API</description>
+    <properties>
+        <java.version>21</java.version>
+        <spring.boot.version>3.2.5</spring.boot.version>
+    </properties>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>${spring.boot.version}</version>
+        <relativePath/>
+    </parent>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/biddingplatform/BiddingPlatformApplication.java
+++ b/src/main/java/com/example/biddingplatform/BiddingPlatformApplication.java
@@ -1,0 +1,11 @@
+package com.example.biddingplatform;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BiddingPlatformApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(BiddingPlatformApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/biddingplatform/DataInitializer.java
+++ b/src/main/java/com/example/biddingplatform/DataInitializer.java
@@ -1,0 +1,44 @@
+package com.example.biddingplatform;
+
+import com.example.biddingplatform.entity.Auction;
+import com.example.biddingplatform.entity.Category;
+import com.example.biddingplatform.repository.AuctionRepository;
+import com.example.biddingplatform.repository.CategoryRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Configuration
+public class DataInitializer {
+
+    @Bean
+    CommandLineRunner initData(AuctionRepository auctionRepository, CategoryRepository categoryRepository) {
+        return args -> {
+            if (categoryRepository.count() == 0) {
+                categoryRepository.save(new Category("fruits", "Fruits", "\uD83C\uDF4E", 25));
+                categoryRepository.save(new Category("vegetables", "Vegetables", "\uD83E\uDD55", 32));
+                categoryRepository.save(new Category("herbs", "Herbs", "\uD83C\uDF3F", 8));
+            }
+
+            if (auctionRepository.count() == 0) {
+                Auction auction = Auction.builder()
+                        .title("Premium Organic Tomatoes")
+                        .description("Fresh, vine-ripened organic tomatoes from local farm")
+                        .currentBid(new BigDecimal("25.50"))
+                        .minimumBid(new BigDecimal("30.00"))
+                        .imageUrl("https://your-cdn.com/images/tomatoes.jpg")
+                        .category("vegetables")
+                        .organic(true)
+                        .weight("5 kg")
+                        .location("California, USA")
+                        .endTime(LocalDateTime.now().plusHours(2))
+                        .createdAt(LocalDateTime.now())
+                        .build();
+                auctionRepository.save(auction);
+            }
+        };
+    }
+}

--- a/src/main/java/com/example/biddingplatform/controller/AuctionController.java
+++ b/src/main/java/com/example/biddingplatform/controller/AuctionController.java
@@ -1,0 +1,55 @@
+package com.example.biddingplatform.controller;
+
+import com.example.biddingplatform.dto.*;
+import com.example.biddingplatform.service.AuctionService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+public class AuctionController {
+
+    private final AuctionService auctionService;
+
+    public AuctionController(AuctionService auctionService) {
+        this.auctionService = auctionService;
+    }
+
+    @GetMapping("/auctions")
+    public ApiResponse<List<AuctionSummaryDto>> getAuctions() {
+        Long userId = 1L; // demo
+        return new ApiResponse<>(true, auctionService.getAuctions(userId), null);
+    }
+
+    @GetMapping("/auctions/{id}")
+    public ResponseEntity<ApiResponse<AuctionDetailDto>> getAuction(@PathVariable Long id) {
+        Long userId = 1L;
+        return auctionService.getAuction(id, userId)
+                .map(dto -> ResponseEntity.ok(new ApiResponse<>(true, dto, null)))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("/auctions/{id}/bids")
+    public ResponseEntity<ApiResponse<BidResponseDto>> placeBid(@PathVariable Long id,
+                                                                @Valid @RequestBody PlaceBidRequest request) {
+        String bidder = "John D."; // demo user
+        return auctionService.placeBid(id, request, bidder)
+                .map(resp -> ResponseEntity.ok(new ApiResponse<>(true, resp, "Bid placed successfully")))
+                .orElse(ResponseEntity.badRequest()
+                        .body(new ApiResponse<>(false, null, "Bid amount must be at least minimum")));
+    }
+
+    @PostMapping("/auctions/{id}/watchlist")
+    public ApiResponse<WatchlistItemDto> watchlist(@PathVariable Long id,
+                                                   @Valid @RequestBody WatchlistActionRequest request) {
+        Long userId = 1L;
+        boolean watchlisted = auctionService.updateWatchlist(id, request, userId);
+        WatchlistItemDto dto = new WatchlistItemDto();
+        dto.setId(id);
+        dto.setWatchlisted(watchlisted);
+        return new ApiResponse<>(true, dto, watchlisted ? "Added to watchlist" : "Removed from watchlist");
+    }
+}

--- a/src/main/java/com/example/biddingplatform/controller/AuctionController.java
+++ b/src/main/java/com/example/biddingplatform/controller/AuctionController.java
@@ -4,6 +4,7 @@ import com.example.biddingplatform.dto.*;
 import com.example.biddingplatform.service.AuctionService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,24 +20,22 @@ public class AuctionController {
     }
 
     @GetMapping("/auctions")
-    public ApiResponse<List<AuctionSummaryDto>> getAuctions() {
-        Long userId = 1L; // demo
-        return new ApiResponse<>(true, auctionService.getAuctions(userId), null);
+    public ApiResponse<List<AuctionSummaryDto>> getAuctions(Authentication authentication) {
+        return new ApiResponse<>(true, auctionService.getAuctions(authentication.getName()), null);
     }
 
     @GetMapping("/auctions/{id}")
-    public ResponseEntity<ApiResponse<AuctionDetailDto>> getAuction(@PathVariable Long id) {
-        Long userId = 1L;
-        return auctionService.getAuction(id, userId)
+    public ResponseEntity<ApiResponse<AuctionDetailDto>> getAuction(@PathVariable Long id, Authentication authentication) {
+        return auctionService.getAuction(id, authentication.getName())
                 .map(dto -> ResponseEntity.ok(new ApiResponse<>(true, dto, null)))
                 .orElse(ResponseEntity.notFound().build());
     }
 
     @PostMapping("/auctions/{id}/bids")
     public ResponseEntity<ApiResponse<BidResponseDto>> placeBid(@PathVariable Long id,
-                                                                @Valid @RequestBody PlaceBidRequest request) {
-        String bidder = "John D."; // demo user
-        return auctionService.placeBid(id, request, bidder)
+                                                                @Valid @RequestBody PlaceBidRequest request,
+                                                                Authentication authentication) {
+        return auctionService.placeBid(id, request, authentication.getName())
                 .map(resp -> ResponseEntity.ok(new ApiResponse<>(true, resp, "Bid placed successfully")))
                 .orElse(ResponseEntity.badRequest()
                         .body(new ApiResponse<>(false, null, "Bid amount must be at least minimum")));
@@ -44,9 +43,9 @@ public class AuctionController {
 
     @PostMapping("/auctions/{id}/watchlist")
     public ApiResponse<WatchlistItemDto> watchlist(@PathVariable Long id,
-                                                   @Valid @RequestBody WatchlistActionRequest request) {
-        Long userId = 1L;
-        boolean watchlisted = auctionService.updateWatchlist(id, request, userId);
+                                                   @Valid @RequestBody WatchlistActionRequest request,
+                                                   Authentication authentication) {
+        boolean watchlisted = auctionService.updateWatchlist(id, request, authentication.getName());
         WatchlistItemDto dto = new WatchlistItemDto();
         dto.setId(id);
         dto.setWatchlisted(watchlisted);

--- a/src/main/java/com/example/biddingplatform/controller/AuthController.java
+++ b/src/main/java/com/example/biddingplatform/controller/AuthController.java
@@ -1,0 +1,62 @@
+package com.example.biddingplatform.controller;
+
+import com.example.biddingplatform.dto.*;
+import com.example.biddingplatform.entity.User;
+import com.example.biddingplatform.repository.UserRepository;
+import com.example.biddingplatform.security.JwtService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
+
+    public AuthController(AuthenticationManager authenticationManager,
+                          UserRepository userRepository,
+                          PasswordEncoder passwordEncoder,
+                          JwtService jwtService) {
+        this.authenticationManager = authenticationManager;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtService = jwtService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<ApiResponse<AuthResponse>> register(@Valid @RequestBody RegisterRequest request) {
+        if (userRepository.existsByUsername(request.username())) {
+            return ResponseEntity.badRequest().body(new ApiResponse<>(false, null, "Username already taken"));
+        }
+        User user = User.builder()
+                .username(request.username())
+                .password(passwordEncoder.encode(request.password()))
+                .role("ROLE_USER")
+                .build();
+        userRepository.save(user);
+        UserDetails userDetails = org.springframework.security.core.userdetails.User
+                .withUsername(user.getUsername())
+                .password(user.getPassword())
+                .authorities(user.getRole())
+                .build();
+        String token = jwtService.generateToken(userDetails);
+        return ResponseEntity.ok(new ApiResponse<>(true, new AuthResponse(token), "User registered"));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<AuthResponse>> login(@Valid @RequestBody LoginRequest request) {
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.username(), request.password()));
+        String token = jwtService.generateToken((UserDetails) authentication.getPrincipal());
+        return ResponseEntity.ok(new ApiResponse<>(true, new AuthResponse(token), "Login successful"));
+    }
+}

--- a/src/main/java/com/example/biddingplatform/controller/CategoryController.java
+++ b/src/main/java/com/example/biddingplatform/controller/CategoryController.java
@@ -1,0 +1,26 @@
+package com.example.biddingplatform.controller;
+
+import com.example.biddingplatform.dto.ApiResponse;
+import com.example.biddingplatform.dto.CategoryDto;
+import com.example.biddingplatform.service.CategoryService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    public CategoryController(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    @GetMapping("/categories")
+    public ApiResponse<List<CategoryDto>> categories() {
+        return new ApiResponse<>(true, categoryService.getCategories(), null);
+    }
+}

--- a/src/main/java/com/example/biddingplatform/controller/StatsController.java
+++ b/src/main/java/com/example/biddingplatform/controller/StatsController.java
@@ -1,0 +1,24 @@
+package com.example.biddingplatform.controller;
+
+import com.example.biddingplatform.dto.ApiResponse;
+import com.example.biddingplatform.dto.StatsDto;
+import com.example.biddingplatform.service.StatsService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class StatsController {
+
+    private final StatsService statsService;
+
+    public StatsController(StatsService statsService) {
+        this.statsService = statsService;
+    }
+
+    @GetMapping("/stats")
+    public ApiResponse<StatsDto> stats() {
+        return new ApiResponse<>(true, statsService.getStats(), null);
+    }
+}

--- a/src/main/java/com/example/biddingplatform/controller/UserController.java
+++ b/src/main/java/com/example/biddingplatform/controller/UserController.java
@@ -4,6 +4,7 @@ import com.example.biddingplatform.dto.ApiResponse;
 import com.example.biddingplatform.dto.BidResponseDto;
 import com.example.biddingplatform.dto.WatchlistItemDto;
 import com.example.biddingplatform.service.UserService;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,14 +22,12 @@ public class UserController {
     }
 
     @GetMapping("/watchlist")
-    public ApiResponse<List<WatchlistItemDto>> watchlist() {
-        Long userId = 1L;
-        return new ApiResponse<>(true, userService.getWatchlist(userId), null);
+    public ApiResponse<List<WatchlistItemDto>> watchlist(Authentication authentication) {
+        return new ApiResponse<>(true, userService.getWatchlist(authentication.getName()), null);
     }
 
     @GetMapping("/bids")
-    public ApiResponse<List<BidResponseDto>> bids() {
-        String bidder = "John D.";
-        return new ApiResponse<>(true, userService.getBids(bidder), null);
+    public ApiResponse<List<BidResponseDto>> bids(Authentication authentication) {
+        return new ApiResponse<>(true, userService.getBids(authentication.getName()), null);
     }
 }

--- a/src/main/java/com/example/biddingplatform/controller/UserController.java
+++ b/src/main/java/com/example/biddingplatform/controller/UserController.java
@@ -1,0 +1,34 @@
+package com.example.biddingplatform.controller;
+
+import com.example.biddingplatform.dto.ApiResponse;
+import com.example.biddingplatform.dto.BidResponseDto;
+import com.example.biddingplatform.dto.WatchlistItemDto;
+import com.example.biddingplatform.service.UserService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/user")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/watchlist")
+    public ApiResponse<List<WatchlistItemDto>> watchlist() {
+        Long userId = 1L;
+        return new ApiResponse<>(true, userService.getWatchlist(userId), null);
+    }
+
+    @GetMapping("/bids")
+    public ApiResponse<List<BidResponseDto>> bids() {
+        String bidder = "John D.";
+        return new ApiResponse<>(true, userService.getBids(bidder), null);
+    }
+}

--- a/src/main/java/com/example/biddingplatform/dto/ApiResponse.java
+++ b/src/main/java/com/example/biddingplatform/dto/ApiResponse.java
@@ -1,0 +1,14 @@
+package com.example.biddingplatform.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private boolean success;
+    private T data;
+    private String message;
+}

--- a/src/main/java/com/example/biddingplatform/dto/AuctionDetailDto.java
+++ b/src/main/java/com/example/biddingplatform/dto/AuctionDetailDto.java
@@ -1,0 +1,28 @@
+package com.example.biddingplatform.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+public class AuctionDetailDto {
+    private Long id;
+    private String title;
+    private String description;
+    private BigDecimal currentBid;
+    private BigDecimal minimumBid;
+    private long timeLeftMs;
+    private String imageUrl;
+    private List<String> additionalImages;
+    private SellerDto seller;
+    private int bidCount;
+    private String category;
+    private boolean organic;
+    private String weight;
+    private LocalDateTime endTime;
+    private LocalDateTime createdAt;
+    private boolean watchlisted;
+    private List<BidHistoryDto> bidHistory;
+}

--- a/src/main/java/com/example/biddingplatform/dto/AuctionSummaryDto.java
+++ b/src/main/java/com/example/biddingplatform/dto/AuctionSummaryDto.java
@@ -1,0 +1,25 @@
+package com.example.biddingplatform.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+public class AuctionSummaryDto {
+    private Long id;
+    private String title;
+    private String description;
+    private BigDecimal currentBid;
+    private BigDecimal minimumBid;
+    private long timeLeftMs;
+    private String imageUrl;
+    private int bidCount;
+    private String category;
+    private boolean organic;
+    private String weight;
+    private String location;
+    private LocalDateTime endTime;
+    private LocalDateTime createdAt;
+    private boolean watchlisted;
+}

--- a/src/main/java/com/example/biddingplatform/dto/AuthResponse.java
+++ b/src/main/java/com/example/biddingplatform/dto/AuthResponse.java
@@ -1,0 +1,10 @@
+package com.example.biddingplatform.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AuthResponse {
+    private String token;
+}

--- a/src/main/java/com/example/biddingplatform/dto/BidHistoryDto.java
+++ b/src/main/java/com/example/biddingplatform/dto/BidHistoryDto.java
@@ -1,0 +1,13 @@
+package com.example.biddingplatform.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+public class BidHistoryDto {
+    private BigDecimal amount;
+    private String bidderName;
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/com/example/biddingplatform/dto/BidResponseDto.java
+++ b/src/main/java/com/example/biddingplatform/dto/BidResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.biddingplatform.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+public class BidResponseDto {
+    private Long bidId;
+    private Long auctionId;
+    private BigDecimal amount;
+    private LocalDateTime timestamp;
+    private boolean winning;
+    private BigDecimal nextMinimumBid;
+}

--- a/src/main/java/com/example/biddingplatform/dto/CategoryDto.java
+++ b/src/main/java/com/example/biddingplatform/dto/CategoryDto.java
@@ -1,0 +1,11 @@
+package com.example.biddingplatform.dto;
+
+import lombok.Data;
+
+@Data
+public class CategoryDto {
+    private String id;
+    private String name;
+    private String icon;
+    private int activeAuctions;
+}

--- a/src/main/java/com/example/biddingplatform/dto/LoginRequest.java
+++ b/src/main/java/com/example/biddingplatform/dto/LoginRequest.java
@@ -1,0 +1,5 @@
+package com.example.biddingplatform.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(@NotBlank String username, @NotBlank String password) {}

--- a/src/main/java/com/example/biddingplatform/dto/PlaceBidRequest.java
+++ b/src/main/java/com/example/biddingplatform/dto/PlaceBidRequest.java
@@ -1,0 +1,7 @@
+package com.example.biddingplatform.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+public record PlaceBidRequest(@NotNull @DecimalMin("0.0") BigDecimal amount) {}

--- a/src/main/java/com/example/biddingplatform/dto/RegisterRequest.java
+++ b/src/main/java/com/example/biddingplatform/dto/RegisterRequest.java
@@ -1,0 +1,5 @@
+package com.example.biddingplatform.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RegisterRequest(@NotBlank String username, @NotBlank String password) {}

--- a/src/main/java/com/example/biddingplatform/dto/SellerDto.java
+++ b/src/main/java/com/example/biddingplatform/dto/SellerDto.java
@@ -1,0 +1,13 @@
+package com.example.biddingplatform.dto;
+
+import lombok.Data;
+
+@Data
+public class SellerDto {
+    private Long id;
+    private String name;
+    private double rating;
+    private boolean verified;
+    private String location;
+    private String memberSince;
+}

--- a/src/main/java/com/example/biddingplatform/dto/StatsDto.java
+++ b/src/main/java/com/example/biddingplatform/dto/StatsDto.java
@@ -1,0 +1,11 @@
+package com.example.biddingplatform.dto;
+
+import lombok.Data;
+
+@Data
+public class StatsDto {
+    private int activeAuctions;
+    private int totalFarmers;
+    private int auctionsEndingToday;
+    private int totalBidsThisWeek;
+}

--- a/src/main/java/com/example/biddingplatform/dto/WatchlistActionRequest.java
+++ b/src/main/java/com/example/biddingplatform/dto/WatchlistActionRequest.java
@@ -1,0 +1,5 @@
+package com.example.biddingplatform.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record WatchlistActionRequest(@NotBlank String action) {}

--- a/src/main/java/com/example/biddingplatform/dto/WatchlistItemDto.java
+++ b/src/main/java/com/example/biddingplatform/dto/WatchlistItemDto.java
@@ -1,0 +1,17 @@
+package com.example.biddingplatform.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+public class WatchlistItemDto {
+    private Long id;
+    private boolean watchlisted;
+    private String title;
+    private BigDecimal currentBid;
+    private long timeLeftMs;
+    private String imageUrl;
+    private LocalDateTime addedToWatchlist;
+}

--- a/src/main/java/com/example/biddingplatform/entity/Auction.java
+++ b/src/main/java/com/example/biddingplatform/entity/Auction.java
@@ -1,0 +1,49 @@
+package com.example.biddingplatform.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "auctions")
+public class Auction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @Column(length = 1000)
+    private String description;
+
+    private BigDecimal currentBid;
+
+    private BigDecimal minimumBid;
+
+    private String imageUrl;
+
+    private String category;
+
+    private boolean organic;
+
+    private String weight;
+
+    private String location;
+
+    private LocalDateTime endTime;
+
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "auction", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Bid> bids = new ArrayList<>();
+}

--- a/src/main/java/com/example/biddingplatform/entity/Bid.java
+++ b/src/main/java/com/example/biddingplatform/entity/Bid.java
@@ -1,0 +1,31 @@
+package com.example.biddingplatform.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "bids")
+public class Bid {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "auction_id")
+    private Auction auction;
+
+    private BigDecimal amount;
+
+    private String bidderName;
+
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/com/example/biddingplatform/entity/Category.java
+++ b/src/main/java/com/example/biddingplatform/entity/Category.java
@@ -1,0 +1,25 @@
+package com.example.biddingplatform.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "categories")
+public class Category {
+
+    @Id
+    private String id;
+
+    private String name;
+
+    private String icon;
+
+    private int activeAuctions;
+}

--- a/src/main/java/com/example/biddingplatform/entity/User.java
+++ b/src/main/java/com/example/biddingplatform/entity/User.java
@@ -1,0 +1,27 @@
+package com.example.biddingplatform.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String role;
+}

--- a/src/main/java/com/example/biddingplatform/entity/WatchlistItem.java
+++ b/src/main/java/com/example/biddingplatform/entity/WatchlistItem.java
@@ -1,0 +1,28 @@
+package com.example.biddingplatform.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "watchlist_items")
+public class WatchlistItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "auction_id")
+    private Auction auction;
+
+    private LocalDateTime addedAt;
+}

--- a/src/main/java/com/example/biddingplatform/mapper/AuctionMapper.java
+++ b/src/main/java/com/example/biddingplatform/mapper/AuctionMapper.java
@@ -1,0 +1,75 @@
+package com.example.biddingplatform.mapper;
+
+import com.example.biddingplatform.dto.*;
+import com.example.biddingplatform.entity.Auction;
+import com.example.biddingplatform.entity.Bid;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.stream.Collectors;
+
+@Component
+public class AuctionMapper {
+
+    public AuctionSummaryDto toSummaryDto(Auction auction, boolean watchlisted) {
+        AuctionSummaryDto dto = new AuctionSummaryDto();
+        dto.setId(auction.getId());
+        dto.setTitle(auction.getTitle());
+        dto.setDescription(auction.getDescription());
+        dto.setCurrentBid(auction.getCurrentBid());
+        dto.setMinimumBid(auction.getMinimumBid());
+        dto.setTimeLeftMs(Duration.between(java.time.LocalDateTime.now(), auction.getEndTime()).toMillis());
+        dto.setImageUrl(auction.getImageUrl());
+        dto.setBidCount(auction.getBids().size());
+        dto.setCategory(auction.getCategory());
+        dto.setOrganic(auction.isOrganic());
+        dto.setWeight(auction.getWeight());
+        dto.setLocation(auction.getLocation());
+        dto.setEndTime(auction.getEndTime());
+        dto.setCreatedAt(auction.getCreatedAt());
+        dto.setWatchlisted(watchlisted);
+        return dto;
+    }
+
+    public AuctionDetailDto toDetailDto(Auction auction, boolean watchlisted) {
+        AuctionDetailDto dto = new AuctionDetailDto();
+        dto.setId(auction.getId());
+        dto.setTitle(auction.getTitle());
+        dto.setDescription(auction.getDescription());
+        dto.setCurrentBid(auction.getCurrentBid());
+        dto.setMinimumBid(auction.getMinimumBid());
+        dto.setTimeLeftMs(Duration.between(java.time.LocalDateTime.now(), auction.getEndTime()).toMillis());
+        dto.setImageUrl(auction.getImageUrl());
+        dto.setAdditionalImages(java.util.List.of());
+        dto.setSeller(new SellerDto());
+        dto.setBidCount(auction.getBids().size());
+        dto.setCategory(auction.getCategory());
+        dto.setOrganic(auction.isOrganic());
+        dto.setWeight(auction.getWeight());
+        dto.setEndTime(auction.getEndTime());
+        dto.setCreatedAt(auction.getCreatedAt());
+        dto.setWatchlisted(watchlisted);
+        dto.setBidHistory(auction.getBids().stream()
+                .sorted((a,b)->b.getTimestamp().compareTo(a.getTimestamp()))
+                .map(this::toBidHistoryDto)
+                .collect(Collectors.toList()));
+        return dto;
+    }
+
+    public BidHistoryDto toBidHistoryDto(Bid bid) {
+        BidHistoryDto dto = new BidHistoryDto();
+        dto.setAmount(bid.getAmount());
+        dto.setBidderName(bid.getBidderName());
+        dto.setTimestamp(bid.getTimestamp());
+        return dto;
+    }
+
+    public WatchlistItemDto toWatchlistDto(Auction auction, WatchlistItemDto dto) {
+        dto.setId(auction.getId());
+        dto.setTitle(auction.getTitle());
+        dto.setCurrentBid(auction.getCurrentBid());
+        dto.setTimeLeftMs(Duration.between(java.time.LocalDateTime.now(), auction.getEndTime()).toMillis());
+        dto.setImageUrl(auction.getImageUrl());
+        return dto;
+    }
+}

--- a/src/main/java/com/example/biddingplatform/repository/AuctionRepository.java
+++ b/src/main/java/com/example/biddingplatform/repository/AuctionRepository.java
@@ -1,0 +1,7 @@
+package com.example.biddingplatform.repository;
+
+import com.example.biddingplatform.entity.Auction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuctionRepository extends JpaRepository<Auction, Long> {
+}

--- a/src/main/java/com/example/biddingplatform/repository/BidRepository.java
+++ b/src/main/java/com/example/biddingplatform/repository/BidRepository.java
@@ -1,0 +1,11 @@
+package com.example.biddingplatform.repository;
+
+import com.example.biddingplatform.entity.Bid;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BidRepository extends JpaRepository<Bid, Long> {
+    List<Bid> findByAuctionIdOrderByTimestampDesc(Long auctionId);
+    List<Bid> findByBidderName(String bidderName);
+}

--- a/src/main/java/com/example/biddingplatform/repository/CategoryRepository.java
+++ b/src/main/java/com/example/biddingplatform/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.biddingplatform.repository;
+
+import com.example.biddingplatform.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, String> {
+}

--- a/src/main/java/com/example/biddingplatform/repository/UserRepository.java
+++ b/src/main/java/com/example/biddingplatform/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.example.biddingplatform.repository;
+
+import com.example.biddingplatform.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+    boolean existsByUsername(String username);
+}

--- a/src/main/java/com/example/biddingplatform/repository/WatchlistRepository.java
+++ b/src/main/java/com/example/biddingplatform/repository/WatchlistRepository.java
@@ -1,0 +1,12 @@
+package com.example.biddingplatform.repository;
+
+import com.example.biddingplatform.entity.WatchlistItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface WatchlistRepository extends JpaRepository<WatchlistItem, Long> {
+    List<WatchlistItem> findByUserId(Long userId);
+    boolean existsByUserIdAndAuctionId(Long userId, Long auctionId);
+    void deleteByUserIdAndAuctionId(Long userId, Long auctionId);
+}

--- a/src/main/java/com/example/biddingplatform/security/CustomUserDetailsService.java
+++ b/src/main/java/com/example/biddingplatform/security/CustomUserDetailsService.java
@@ -1,0 +1,31 @@
+package com.example.biddingplatform.security;
+
+import com.example.biddingplatform.entity.User;
+import com.example.biddingplatform.repository.UserRepository;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        return new org.springframework.security.core.userdetails.User(
+                user.getUsername(),
+                user.getPassword(),
+                Collections.singletonList(new SimpleGrantedAuthority(user.getRole())));
+    }
+}

--- a/src/main/java/com/example/biddingplatform/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/biddingplatform/security/JwtAuthenticationFilter.java
@@ -1,0 +1,44 @@
+package com.example.biddingplatform.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtService jwtService, UserDetailsService userDetailsService) {
+        this.jwtService = jwtService;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            String username = jwtService.extractUsername(token);
+            if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                if (jwtService.isTokenValid(token, userDetails)) {
+                    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities());
+                    SecurityContextHolder.getContext().setAuthentication(authToken);
+                }
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/biddingplatform/security/JwtService.java
+++ b/src/main/java/com/example/biddingplatform/security/JwtService.java
@@ -1,0 +1,53 @@
+package com.example.biddingplatform.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.security.Key;
+import java.util.Date;
+
+@Service
+public class JwtService {
+
+    @Value("${app.jwt.secret}")
+    private String secret;
+
+    private Key getSigningKey() {
+        return Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    public String extractUsername(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    public String generateToken(UserDetails userDetails) {
+        return Jwts.builder()
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean isTokenValid(String token, UserDetails userDetails) {
+        String username = extractUsername(token);
+        return username.equals(userDetails.getUsername()) && !isTokenExpired(token);
+    }
+
+    private boolean isTokenExpired(String token) {
+        return getClaims(token).getExpiration().before(new Date());
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/com/example/biddingplatform/security/SecurityConfig.java
+++ b/src/main/java/com/example/biddingplatform/security/SecurityConfig.java
@@ -1,0 +1,60 @@
+package com.example.biddingplatform.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomUserDetailsService userDetailsService;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
+                          CustomUserDetailsService userDetailsService) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .anyRequest().authenticated())
+                .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authenticationProvider(authenticationProvider())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder());
+        return provider;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}

--- a/src/main/java/com/example/biddingplatform/service/AuctionService.java
+++ b/src/main/java/com/example/biddingplatform/service/AuctionService.java
@@ -1,0 +1,94 @@
+package com.example.biddingplatform.service;
+
+import com.example.biddingplatform.dto.*;
+import com.example.biddingplatform.entity.Auction;
+import com.example.biddingplatform.entity.Bid;
+import com.example.biddingplatform.entity.WatchlistItem;
+import com.example.biddingplatform.mapper.AuctionMapper;
+import com.example.biddingplatform.repository.AuctionRepository;
+import com.example.biddingplatform.repository.BidRepository;
+import com.example.biddingplatform.repository.WatchlistRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class AuctionService {
+    private final AuctionRepository auctionRepository;
+    private final BidRepository bidRepository;
+    private final WatchlistRepository watchlistRepository;
+    private final AuctionMapper auctionMapper;
+
+    public AuctionService(AuctionRepository auctionRepository,
+                          BidRepository bidRepository,
+                          WatchlistRepository watchlistRepository,
+                          AuctionMapper auctionMapper) {
+        this.auctionRepository = auctionRepository;
+        this.bidRepository = bidRepository;
+        this.watchlistRepository = watchlistRepository;
+        this.auctionMapper = auctionMapper;
+    }
+
+    public List<AuctionSummaryDto> getAuctions(Long userId) {
+        return auctionRepository.findAll().stream()
+                .map(a -> auctionMapper.toSummaryDto(a, watchlistRepository.existsByUserIdAndAuctionId(userId, a.getId())))
+                .collect(Collectors.toList());
+    }
+
+    public Optional<AuctionDetailDto> getAuction(Long id, Long userId) {
+        return auctionRepository.findById(id)
+                .map(a -> auctionMapper.toDetailDto(a, watchlistRepository.existsByUserIdAndAuctionId(userId, a.getId())));
+    }
+
+    @Transactional
+    public Optional<BidResponseDto> placeBid(Long auctionId, PlaceBidRequest request, String bidderName) {
+        return auctionRepository.findById(auctionId).map(auction -> {
+            BigDecimal min = auction.getCurrentBid().max(auction.getMinimumBid());
+            if (request.amount().compareTo(min) < 0) {
+                return null;
+            }
+            Bid bid = Bid.builder()
+                    .auction(auction)
+                    .amount(request.amount())
+                    .bidderName(bidderName)
+                    .timestamp(LocalDateTime.now())
+                    .build();
+            bidRepository.save(bid);
+            auction.setCurrentBid(request.amount());
+            BidResponseDto resp = new BidResponseDto();
+            resp.setBidId(bid.getId());
+            resp.setAuctionId(auctionId);
+            resp.setAmount(request.amount());
+            resp.setTimestamp(bid.getTimestamp());
+            resp.setWinning(true);
+            resp.setNextMinimumBid(request.amount().add(BigDecimal.valueOf(2))); // simple increment
+            return resp;
+        });
+    }
+
+    @Transactional
+    public boolean updateWatchlist(Long auctionId, WatchlistActionRequest request, Long userId) {
+        if ("add".equalsIgnoreCase(request.action())) {
+            if (watchlistRepository.existsByUserIdAndAuctionId(userId, auctionId)) {
+                return true;
+            }
+            Auction auction = auctionRepository.findById(auctionId).orElseThrow();
+            WatchlistItem item = WatchlistItem.builder()
+                    .auction(auction)
+                    .userId(userId)
+                    .addedAt(LocalDateTime.now())
+                    .build();
+            watchlistRepository.save(item);
+            return true;
+        } else if ("remove".equalsIgnoreCase(request.action())) {
+            watchlistRepository.deleteByUserIdAndAuctionId(userId, auctionId);
+            return false;
+        }
+        throw new IllegalArgumentException("Unknown action");
+    }
+}

--- a/src/main/java/com/example/biddingplatform/service/CategoryService.java
+++ b/src/main/java/com/example/biddingplatform/service/CategoryService.java
@@ -1,0 +1,28 @@
+package com.example.biddingplatform.service;
+
+import com.example.biddingplatform.dto.CategoryDto;
+import com.example.biddingplatform.repository.CategoryRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+
+    public CategoryService(CategoryRepository categoryRepository) {
+        this.categoryRepository = categoryRepository;
+    }
+
+    public List<CategoryDto> getCategories() {
+        return categoryRepository.findAll().stream().map(cat -> {
+            CategoryDto dto = new CategoryDto();
+            dto.setId(cat.getId());
+            dto.setName(cat.getName());
+            dto.setIcon(cat.getIcon());
+            dto.setActiveAuctions(cat.getActiveAuctions());
+            return dto;
+        }).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/biddingplatform/service/StatsService.java
+++ b/src/main/java/com/example/biddingplatform/service/StatsService.java
@@ -1,0 +1,16 @@
+package com.example.biddingplatform.service;
+
+import com.example.biddingplatform.dto.StatsDto;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StatsService {
+    public StatsDto getStats() {
+        StatsDto dto = new StatsDto();
+        dto.setActiveAuctions(150);
+        dto.setTotalFarmers(1200);
+        dto.setAuctionsEndingToday(45);
+        dto.setTotalBidsThisWeek(2800);
+        return dto;
+    }
+}

--- a/src/main/java/com/example/biddingplatform/service/UserService.java
+++ b/src/main/java/com/example/biddingplatform/service/UserService.java
@@ -1,0 +1,53 @@
+package com.example.biddingplatform.service;
+
+import com.example.biddingplatform.dto.WatchlistItemDto;
+import com.example.biddingplatform.dto.BidResponseDto;
+import com.example.biddingplatform.mapper.AuctionMapper;
+import com.example.biddingplatform.repository.AuctionRepository;
+import com.example.biddingplatform.repository.BidRepository;
+import com.example.biddingplatform.repository.WatchlistRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class UserService {
+    private final WatchlistRepository watchlistRepository;
+    private final AuctionRepository auctionRepository;
+    private final BidRepository bidRepository;
+    private final AuctionMapper auctionMapper;
+
+    public UserService(WatchlistRepository watchlistRepository,
+                       AuctionRepository auctionRepository,
+                       BidRepository bidRepository,
+                       AuctionMapper auctionMapper) {
+        this.watchlistRepository = watchlistRepository;
+        this.auctionRepository = auctionRepository;
+        this.bidRepository = bidRepository;
+        this.auctionMapper = auctionMapper;
+    }
+
+    public List<WatchlistItemDto> getWatchlist(Long userId) {
+        return watchlistRepository.findByUserId(userId).stream().map(item -> {
+            WatchlistItemDto dto = new WatchlistItemDto();
+            dto.setAddedToWatchlist(item.getAddedAt());
+            auctionRepository.findById(item.getAuction().getId())
+                    .ifPresent(auction -> auctionMapper.toWatchlistDto(auction, dto));
+            return dto;
+        }).collect(Collectors.toList());
+    }
+
+    public List<BidResponseDto> getBids(String bidderName) {
+        return bidRepository.findByBidderName(bidderName).stream().map(bid -> {
+            BidResponseDto dto = new BidResponseDto();
+            dto.setBidId(bid.getId());
+            dto.setAuctionId(bid.getAuction().getId());
+            dto.setAmount(bid.getAmount());
+            dto.setTimestamp(bid.getTimestamp());
+            dto.setWinning(bid.getAuction().getCurrentBid().equals(bid.getAmount()));
+            dto.setNextMinimumBid(bid.getAmount().add(java.math.BigDecimal.valueOf(2)));
+            return dto;
+        }).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/biddingplatform/service/UserService.java
+++ b/src/main/java/com/example/biddingplatform/service/UserService.java
@@ -6,6 +6,7 @@ import com.example.biddingplatform.mapper.AuctionMapper;
 import com.example.biddingplatform.repository.AuctionRepository;
 import com.example.biddingplatform.repository.BidRepository;
 import com.example.biddingplatform.repository.WatchlistRepository;
+import com.example.biddingplatform.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,18 +18,22 @@ public class UserService {
     private final AuctionRepository auctionRepository;
     private final BidRepository bidRepository;
     private final AuctionMapper auctionMapper;
+    private final UserRepository userRepository;
 
     public UserService(WatchlistRepository watchlistRepository,
                        AuctionRepository auctionRepository,
                        BidRepository bidRepository,
-                       AuctionMapper auctionMapper) {
+                       AuctionMapper auctionMapper,
+                       UserRepository userRepository) {
         this.watchlistRepository = watchlistRepository;
         this.auctionRepository = auctionRepository;
         this.bidRepository = bidRepository;
         this.auctionMapper = auctionMapper;
+        this.userRepository = userRepository;
     }
 
-    public List<WatchlistItemDto> getWatchlist(Long userId) {
+    public List<WatchlistItemDto> getWatchlist(String username) {
+        Long userId = userRepository.findByUsername(username).orElseThrow().getId();
         return watchlistRepository.findByUserId(userId).stream().map(item -> {
             WatchlistItemDto dto = new WatchlistItemDto();
             dto.setAddedToWatchlist(item.getAddedAt());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.h2.console.enabled=true
+spring.jpa.hibernate.ddl-auto=create-drop

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,6 @@
-spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.h2.console.enabled=true
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.datasource.url=jdbc:postgresql://localhost:5432/bidding
+spring.datasource.username=bidding
+spring.datasource.password=bidding
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=none

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,4 @@ spring.datasource.password=bidding
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=none
+app.jwt.secret=change-me-secret-key-change-me-secret-key

--- a/src/test/java/com/example/biddingplatform/BiddingPlatformApplicationTests.java
+++ b/src/test/java/com/example/biddingplatform/BiddingPlatformApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.biddingplatform;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BiddingPlatformApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold Spring Boot 3 project targeting Java 21
- define entities, DTOs, services, and controllers for auctions, bids, categories, watchlists, and stats
- preload sample data using H2 in-memory database

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b042cfca788323a652d6a5ab84b1cd