### PR TITLE
Allow unauthenticated access to auction listings

### DIFF
--- a/src/main/java/com/example/biddingplatform/controller/AuctionController.java
+++ b/src/main/java/com/example/biddingplatform/controller/AuctionController.java
@@ -21,12 +21,14 @@ public class AuctionController {
 
     @GetMapping("/auctions")
     public ApiResponse<List<AuctionSummaryDto>> getAuctions(Authentication authentication) {
-        return new ApiResponse<>(true, auctionService.getAuctions(authentication.getName()), null);
+        String username = authentication != null ? authentication.getName() : null;
+        return new ApiResponse<>(true, auctionService.getAuctions(username), null);
     }
 
     @GetMapping("/auctions/{id}")
     public ResponseEntity<ApiResponse<AuctionDetailDto>> getAuction(@PathVariable Long id, Authentication authentication) {
-        return auctionService.getAuction(id, authentication.getName())
+        String username = authentication != null ? authentication.getName() : null;
+        return auctionService.getAuction(id, username)
                 .map(dto -> ResponseEntity.ok(new ApiResponse<>(true, dto, null)))
                 .orElse(ResponseEntity.notFound().build());
     }

--- a/src/main/java/com/example/biddingplatform/security/SecurityConfig.java
+++ b/src/main/java/com/example/biddingplatform/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.biddingplatform.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -33,6 +34,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/auctions/**").permitAll()
                         .anyRequest().authenticated())
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authenticationProvider(authenticationProvider())

--- a/src/main/java/com/example/biddingplatform/service/AuctionService.java
+++ b/src/main/java/com/example/biddingplatform/service/AuctionService.java
@@ -39,16 +39,30 @@ public class AuctionService {
     }
 
     public List<AuctionSummaryDto> getAuctions(String username) {
-        Long userId = userRepository.findByUsername(username).orElseThrow().getId();
+        Long userId = null;
+        if (username != null) {
+            userId = userRepository.findByUsername(username)
+                    .map(u -> u.getId())
+                    .orElse(null);
+        }
+        Long finalUserId = userId;
         return auctionRepository.findAll().stream()
-                .map(a -> auctionMapper.toSummaryDto(a, watchlistRepository.existsByUserIdAndAuctionId(userId, a.getId())))
+                .map(a -> auctionMapper.toSummaryDto(a,
+                        finalUserId != null && watchlistRepository.existsByUserIdAndAuctionId(finalUserId, a.getId())))
                 .collect(Collectors.toList());
     }
 
     public Optional<AuctionDetailDto> getAuction(Long id, String username) {
-        Long userId = userRepository.findByUsername(username).orElseThrow().getId();
+        Long userId = null;
+        if (username != null) {
+            userId = userRepository.findByUsername(username)
+                    .map(u -> u.getId())
+                    .orElse(null);
+        }
+        Long finalUserId = userId;
         return auctionRepository.findById(id)
-                .map(a -> auctionMapper.toDetailDto(a, watchlistRepository.existsByUserIdAndAuctionId(userId, a.getId())));
+                .map(a -> auctionMapper.toDetailDto(a,
+                        finalUserId != null && watchlistRepository.existsByUserIdAndAuctionId(finalUserId, a.getId())));
     }
 
     @Transactional


### PR DESCRIPTION
## Summary
- Allow public GET access to `/api/v1/auctions` and `/api/v1/auctions/{id}`
- Handle optional authentication in auction controller and service to support anonymous users

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dca18e1c8323a85795c27deabaa7