### PR TITLE
Seed multiple auctions

### DIFF
--- a/src/main/java/com/example/biddingplatform/DataInitializer.java
+++ b/src/main/java/com/example/biddingplatform/DataInitializer.java
@@ -24,7 +24,7 @@ public class DataInitializer {
             }
 
             if (auctionRepository.count() == 0) {
-                Auction auction = Auction.builder()
+                Auction tomatoes = Auction.builder()
                         .title("Premium Organic Tomatoes")
                         .description("Fresh, vine-ripened organic tomatoes from local farm")
                         .currentBid(new BigDecimal("25.50"))
@@ -37,7 +37,52 @@ public class DataInitializer {
                         .endTime(LocalDateTime.now().plusHours(2))
                         .createdAt(LocalDateTime.now())
                         .build();
-                auctionRepository.save(auction);
+                auctionRepository.save(tomatoes);
+
+                Auction apples = Auction.builder()
+                        .title("Crisp Gala Apples")
+                        .description("Sweet and crunchy Gala apples freshly picked")
+                        .currentBid(new BigDecimal("15.00"))
+                        .minimumBid(new BigDecimal("18.00"))
+                        .imageUrl("https://your-cdn.com/images/apples.jpg")
+                        .category("fruits")
+                        .organic(true)
+                        .weight("3 kg")
+                        .location("Washington, USA")
+                        .endTime(LocalDateTime.now().plusHours(4))
+                        .createdAt(LocalDateTime.now())
+                        .build();
+                auctionRepository.save(apples);
+
+                Auction lettuce = Auction.builder()
+                        .title("Hydroponic Lettuce")
+                        .description("Green, hydroponically grown lettuce heads")
+                        .currentBid(new BigDecimal("10.00"))
+                        .minimumBid(new BigDecimal("12.00"))
+                        .imageUrl("https://your-cdn.com/images/lettuce.jpg")
+                        .category("vegetables")
+                        .organic(false)
+                        .weight("2 kg")
+                        .location("Florida, USA")
+                        .endTime(LocalDateTime.now().plusHours(3))
+                        .createdAt(LocalDateTime.now())
+                        .build();
+                auctionRepository.save(lettuce);
+
+                Auction basil = Auction.builder()
+                        .title("Fresh Basil Bunches")
+                        .description("Aromatic basil leaves perfect for cooking")
+                        .currentBid(new BigDecimal("5.00"))
+                        .minimumBid(new BigDecimal("7.50"))
+                        .imageUrl("https://your-cdn.com/images/basil.jpg")
+                        .category("herbs")
+                        .organic(true)
+                        .weight("1 kg")
+                        .location("Oregon, USA")
+                        .endTime(LocalDateTime.now().plusHours(6))
+                        .createdAt(LocalDateTime.now())
+                        .build();
+                auctionRepository.save(basil);
             }
         };
     }


### PR DESCRIPTION
## Summary
- expand seeding logic to include additional sample auctions for apples, lettuce, and basil

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e52171f083238133ae97cbacb293